### PR TITLE
Add i18n translation for equipment components

### DIFF
--- a/src/components/equipment/EquipmentSlotDropdown.tsx
+++ b/src/components/equipment/EquipmentSlotDropdown.tsx
@@ -4,6 +4,7 @@ import {
   type SearchableSelectOption,
 } from "@/src/components/ui/SearchableSelect";
 import { Tooltip } from "@/src/components/ui/Tooltip";
+import { i18n } from "@/src/lib/i18n";
 import { getGearAffixes } from "@/src/tli/calcs/affix-collectors";
 import type { Gear } from "@/src/tli/core";
 import type { GearSlot } from "../../lib/types";
@@ -118,7 +119,7 @@ export const EquipmentSlotDropdown: React.FC<EquipmentSlotDropdownProps> = ({
         options={compatibleItems.map((item) => ({
           // biome-ignore lint/style/noNonNullAssertion: inventory items always have id
           value: item.id!,
-          label: item.legendaryName ?? item.equipmentType,
+          label: i18n._(item.legendaryName ?? item.equipmentType),
           sublabel: `${getGearAffixes(item).length} affixes`,
         }))}
         placeholder="-- None --"

--- a/src/components/equipment/InventoryItem.tsx
+++ b/src/components/equipment/InventoryItem.tsx
@@ -1,5 +1,6 @@
 import { Tooltip } from "@/src/components/ui/Tooltip";
 import { useTooltip } from "@/src/hooks/useTooltip";
+import { i18n } from "@/src/lib/i18n";
 import { getGearAffixes } from "@/src/tli/calcs/affix-collectors";
 import type { Gear } from "@/src/tli/core";
 import { GearTooltipContent } from "./GearTooltipContent";
@@ -32,7 +33,7 @@ export const InventoryItem: React.FC<InventoryItemProps> = ({
     >
       <div className="flex items-center gap-2">
         <span className="font-medium text-zinc-50 text-sm">
-          {item.legendaryName ?? item.equipmentType}
+          {i18n._(item.legendaryName ?? item.equipmentType)}
         </span>
         {isLegendary && (
           <span className="text-xs text-amber-400 font-medium">Legendary</span>

--- a/src/scripts/generate-legendary-translate.ts
+++ b/src/scripts/generate-legendary-translate.ts
@@ -1,7 +1,6 @@
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { program } from "commander";
-import { url } from "zod";
 import { Legendaries } from "@/src/data/legendary/legendaries";
 import type { Legendary } from "@/src/data/legendary/types";
 import {
@@ -153,7 +152,7 @@ const main = async (options: Options) => {
     await fetchLegendaryPages("cn");
     console.log("");
   }
-  // await generateLegendaryTS();
+  await generateLegendaryTS();
   await generateLegendaryPO();
 };
 


### PR DESCRIPTION
- Translate item labels using i18n._()
- fix src/scripts/generate-legendary-translate.ts lint error

<img width="529" height="700" alt="截屏2026-01-11 21 52 11" src="https://github.com/user-attachments/assets/b9eff5f9-895a-4ce0-b1b1-192ae48d2168" />
