### PR TITLE
Treat vite:dynamic-import-vars warning as error

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,10 @@ export default defineConfig({
     rollupOptions: {
       onwarn(warning, warn) {
         // Catch warnings related to dynamic-import-vars plugin
-        if (warning.plugin === 'vite:dynamic-import-vars' || warning.code === 'DYNAMIC_IMPORT_VARIABLE') {
+        if (
+          warning.plugin === "vite:dynamic-import-vars" ||
+          warning.code === "DYNAMIC_IMPORT_VARIABLE"
+        ) {
           throw new Error(`Invalid dynamic import path: ${warning.message}`);
         }
         // Other warnings are displayed normally


### PR DESCRIPTION
When run build:
```
[plugin vite:dynamic-import-vars] src/lib/i18n.ts: invalid import "../locales/${locale}/${module}". A file extension must be included in the static part of the import. For example: import(`./foo/${bar}.js`) 
```
The warning can't be ignored.  It remind that rollup don't import the ../locales/${locale}/${module} file due to lack '.ts'