### PR TITLE
Reland: convert static imports to dynamic lazy loading with caching

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,29 +1,28 @@
-import { i18n } from "@lingui/core";
-import { messages as enCommonMessages } from "@/src/locales/en/common";
-import { messages as enLegendariesMessages } from "@/src/locales/en/legendaries";
-import { messages as enSkillMessages } from "@/src/locales/en/skills";
-import { messages as enTalentMessages } from "@/src/locales/en/talents";
-import { messages as zhCommonMessages } from "@/src/locales/zh/common";
-import { messages as zhLegendariesMessages } from "@/src/locales/zh/legendaries";
-import { messages as zhSkillMessages } from "@/src/locales/zh/skills";
-import { messages as zhTalentMessages } from "@/src/locales/zh/talents";
+import { i18n, type Messages } from "@lingui/core";
 
 export type Locale = "en" | "zh";
 
-const localeMessages: Record<Locale, typeof enCommonMessages> = {
-  en: {
-    ...enCommonMessages,
-    ...enLegendariesMessages,
-    ...enTalentMessages,
-    ...enSkillMessages,
-  },
-  zh: {
-    ...zhCommonMessages,
-    ...zhLegendariesMessages,
-    ...zhTalentMessages,
-    ...zhSkillMessages,
-  },
-};
+const modules = ["common", "legendaries", "talents", "skills"] as const;
+
+async function loadMessages(locale: Locale): Promise<Messages> {
+  const allMessages: Messages = {};
+
+  await Promise.all(
+    modules.map(async (module) => {
+      try {
+        const mod = await import(`../locales/${locale}/${module}.ts`);
+        if (mod.messages) {
+          Object.assign(allMessages, mod.messages);
+        }
+      } catch (e) {
+        console.warn(`[i18n] Failed to load ${locale}/${module}.ts:`, e);
+      }
+    }),
+  );
+  return allMessages;
+}
+
+const messageCache: Record<Locale, Messages | null> = { en: null, zh: null };
 
 export const defaultLocale: Locale = "en";
 
@@ -32,8 +31,13 @@ export const SUPPORTED_LOCALES = [
   { locale: "zh" as const, name: "简体中文" },
 ] as const;
 
-export const loadLocale = (locale: Locale): void => {
-  i18n.load(locale, localeMessages[locale]);
+export const loadLocale = async (locale: Locale): Promise<void> => {
+  let messages = messageCache[locale];
+  if (!messages) {
+    messages = await loadMessages(locale);
+    messageCache[locale] = messages;
+  }
+  i18n.load(locale, messages);
   i18n.activate(locale);
 };
 
@@ -62,9 +66,9 @@ export const detectBrowserLocale = (): Locale => {
   return defaultLocale;
 };
 
-export const setStoredLocale = (locale: Locale): void => {
+export const setStoredLocale = async (locale: Locale): Promise<void> => {
   localStorage.setItem("locale", locale);
-  loadLocale(locale);
+  await loadLocale(locale);
 };
 
 // Initialize with stored locale, or auto-detect from browser language
@@ -80,7 +84,8 @@ const initialLocale = ((): Locale => {
   setStoredLocale(detected);
   return detected;
 })();
-loadLocale(initialLocale);
+
+await loadLocale(initialLocale);
 
 // Expose for debugging
 if (typeof window !== "undefined") {


### PR DESCRIPTION
- Replace static imports with dynamic import() for code splitting
- Convert loadLocale and setStoredLocale to async functions

Fix #43
